### PR TITLE
Do not link the `bytes` library

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,5 @@
 (library
  (name        rope)
  (public_name rope)
- (libraries  bytes)
  (synopsis  "Ropes (heavyweight strings)"))
 


### PR DESCRIPTION
This removes an unnecessary dependency.